### PR TITLE
a promise out of MockBuilder should be triggered

### DIFF
--- a/src/app/courses-page/course-search/course-search.component.spec.ts
+++ b/src/app/courses-page/course-search/course-search.component.spec.ts
@@ -13,8 +13,8 @@ describe('CourseSearchComponent', () => {
   let buttonEl: DebugElement;
   const defaultValue = 'course1';
 
-  beforeEach(() => {
-    MockBuilder(CourseSearchComponent).keep(FormsModule);
+  beforeEach(async () => {
+    await MockBuilder(CourseSearchComponent).keep(FormsModule);
     fixture = TestBed.createComponent(CourseSearchComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();


### PR DESCRIPTION
`MockBuilder(CourseSearchComponent).keep(FormsModule)` doesn't do anything.
Either `.build()` or `.then() / async` should be called to proceed with configuring `TestBed`.

The info is here: https://www.npmjs.com/package/ng-mocks#mockbuilder-factory